### PR TITLE
Update to config path within plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -30,7 +30,7 @@
         </config-file>
 
         <!-- Cordova >= 3.0.0 -->
-        <config-file target="config.xml" parent="/*">
+        <config-file target="res/xml/config.xml" parent="/*">
             <feature name="InAppBillingPlugin">
 				<param name="android-package" value="com.smartmobilesoftware.inappbilling.InAppBillingPlugin"/>
                 <param name="PURCHASE_G_KEY" value="void" />


### PR DESCRIPTION
Excellent work on this plugin. Thank you for your work.

The config file path is set as <config-file target="config.xml" parent="/*">.
This throws an error "class not found" and the config file is not updated correctly on build.

The original source it is set within the res/xml/ folders. <config-file target="res/xml/config.xml" parent="/*">
It works fine with this path.
